### PR TITLE
add tox and make travis use it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-python:
-  - "2.7"
-install: pip install -r requirements.txt --use-mirrors
-script: python run-tests.py
+python: "2.7"
+install: pip install tox
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps = -rrequirements.txt
+commands = python run-tests.py


### PR DESCRIPTION
By putting the test config in tox.ini, developers and travis can both just run tox to run the tests. Now everyone can easily run the tests in exactly the same way.
