### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,4 @@
-.. image:: https://secure.travis-ci.org/fox-it/django_auth_policy.png?branch=master
-   :target: http://travis-ci.org/fox-it/django_auth_policy
+(this is a port for python 2.6)
 
 Django Auth Policy is a set of tools to enforce various authentication
 policies when using the Django Web Framework (http://www.djangoproject.com/).

--- a/django_auth_policy/forms.py
+++ b/django_auth_policy/forms.py
@@ -1,5 +1,9 @@
 import logging
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # python 2.6 or earlier, use backport
+    from ordereddict import OrderedDict
 
 from django import forms
 from django.utils.translation import ugettext as _

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django>=1.5
+ordereddict==1.1


### PR DESCRIPTION
django-auth-policy is almost 2.6 compatible, the only change is with OrderedDict that can be installed via a port.
